### PR TITLE
Revamped smartercamera to be simpler and smarter.

### DIFF
--- a/cecs343/Assets/Scripts/SmarterCamera.cs
+++ b/cecs343/Assets/Scripts/SmarterCamera.cs
@@ -5,34 +5,25 @@ public class SmarterCamera : MonoBehaviour {
 
     public GameObject player;
     public float xThreshold, yThreshold;
-    public float followSpeed;
     public int maxZoom, minZoom;
+    public float smoothCoeff;
+
+    private Vector3 velocity = Vector3.zero;
 
     // Use this for initialization
     void Start () {
         Camera.main.orthographicSize = 4;
-        followSpeed = 1*GameObject.Find("Player").GetComponent<PlayerMovement>().speed;
 	}
 	
 	// Update is called once per frame
 	void LateUpdate () {
-        var position = Camera.main.WorldToViewportPoint(player.transform.position);
+        var viewPosition = Camera.main.WorldToViewportPoint(player.transform.position);
+        var position = player.transform.position;
+        position.z = transform.position.z;
 
-        if(position.x < 1.0/xThreshold)
+        if(viewPosition.x < 1.0/xThreshold || viewPosition.x > (xThreshold-1)/xThreshold || viewPosition.y < 1.0 / yThreshold || viewPosition.y > (yThreshold-1)/yThreshold)
         {
-            transform.Translate(followSpeed*-1*Time.deltaTime, 0, 0); 
-        }
-        if(position.x > (xThreshold-1)/xThreshold)
-        {
-            transform.Translate(followSpeed * Time.deltaTime, 0, 0);
-        }
-        if(position.y < 1.0 / yThreshold)
-        {
-            transform.Translate(0, followSpeed * -1 * Time.deltaTime, 0);
-        }
-        if(position.y > (yThreshold-1)/ yThreshold)
-        {
-            transform.Translate(0, followSpeed * Time.deltaTime, 0);
+            transform.position = Vector3.SmoothDamp(transform.position, position, ref velocity, smoothCoeff);
         }
 
         if(Input.GetKeyDown(KeyCode.Equals)) zoomIn();


### PR DESCRIPTION
-followspeed
+smoothCoeff: modifies how quickly the camera accelerates to the player.
lower means the camera reaches the player faster. Recommended setting:
.4